### PR TITLE
2 heston model

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ delta_european(spots, strikes, expires, vols, discount_rates, dtype=jnp.float32)
     - Geometric brownian motion
       - Univariate 
       - Multivariate
+    - Heston
+      - Univariate
+      - Multivariate
 
 ## Building the Library Locally
 

--- a/jaxfin/models/gbm/gbm.py
+++ b/jaxfin/models/gbm/gbm.py
@@ -5,6 +5,8 @@ import jax
 import jax.numpy as jnp
 from jax import random
 
+from ..utils import check_symmetric
+
 
 class UnivGeometricBrownianMotion:
     """
@@ -150,7 +152,7 @@ class MultiGeometricBrownianMotion:
         if dtype is None:
             raise ValueError("dtype must not be None")
 
-        if not _check_symmetric(corr, 1e-8):
+        if not check_symmetric(corr, 1e-8):
             raise ValueError("Correlation matrix must be symmetric")
 
         if not jnp.array_equal(jnp.diag(corr), jnp.ones(corr.shape[0])):
@@ -213,7 +215,7 @@ class MultiGeometricBrownianMotion:
             maturity (float): Time in years.
             n (int): Number of steps.
             n_sim (int): Number of simulations.
-        
+
         Returns:
             jax.Array: Array containing the sample paths.
         """
@@ -240,14 +242,3 @@ class MultiGeometricBrownianMotion:
         cumsum = cumsum.transpose((1, 2, 0))
         samples = self._s0 * jnp.exp(cumsum)
         return samples.transpose(1, 0, 2)[::-1, :, :]
-
-
-def _check_symmetric(a: jax.Array, tol=1e-8):
-    """
-    Check if a matrix is symmetric
-
-    :param a: (jax.Array): Matrix to check
-    :param tol: (float): Tolerance for the check
-    :return: (bool): True if the matrix is symmetric
-    """
-    return jnp.all(jnp.abs(a - a.T) < tol)

--- a/jaxfin/models/gbm/gbm.py
+++ b/jaxfin/models/gbm/gbm.py
@@ -28,13 +28,16 @@ class UnivGeometricBrownianMotion:
         sigma: Union[jax.Array, float],
         dtype: Optional[jax.numpy.dtype] = jnp.float32,
     ):
-        """
-        GBM constructor
+        """GBM constructor
 
-        :param s0: (Union[jax.Array, float]): Initial value of the GBM
-        :param mean: (Union[jax.Array, float]): Mean of the GBM
-        :param sigma: (Union[jax.Array, float]): Standard deviation of the GBM
-        :param dtype: (Optional[jax.numpy.dtype]): Underlying dtype of the GBM
+        Args:
+            s0 (Union[jax.Array, float]): The initial value of the GBM
+            mean (Union[jax.Array, float]): The drift term (mean) of the GBM
+            sigma (Union[jax.Array, float]): The standard deviation of the GBM
+            dtype (Optional[jax.numpy.dtype], optional): The dtype of the GBM. Defaults to jnp.float32.
+
+        Raises:
+            ValueError: When the dtype is None
         """
         if dtype is None:
             raise ValueError("dtype must not be None")
@@ -46,42 +49,51 @@ class UnivGeometricBrownianMotion:
 
     @property
     def mean(self) -> jax.Array:
-        """
-        :return: Returns the mean of the GBM
+        """Return the mean of the GBM
+
+        Returns:
+            jax.Array: The mean of the GBM
         """
         return self._mean
 
     @property
     def sigma(self) -> jax.Array:
-        """
-        :return: Returns the standard deviation of the GBM
+        """Return the standard deviation of the GBM
+
+        Returns:
+            jax.Array: The standard deviation of the GBM
         """
         return self._sigma
 
     @property
     def s0(self) -> jax.Array:
-        """
-        :return: Returns the initial value of the GBM
+        """Return the initial value of the GBM
+
+        Returns:
+            jax.Array: The initial value of the GBM
         """
         return self._s0
 
     @property
     def dtype(self) -> jax.numpy.dtype:
-        """
-        :return: Returns the underlying dtype of the GBM
+        """Return the underlying dtype of the GBM
+
+        Returns:
+            jax.numpy.dtype: The dtype of the GBM
         """
         return self._dtype
 
-    def simulate_paths(
-        self, seed: int, maturity: float, n: int, n_sim: int
-    ) -> jax.Array:
+    def sample_paths(self, seed: int, maturity: float, n: int, n_sim: int) -> jax.Array:
         """
-        Simulate a sample of paths from the GBM
+        Simulate a sample of paths from the Geometric Brownian Motion (GBM).
 
-        :param maturity: time in years
-        :param n: (int): number of steps
-        :param n_sim: (int): number of simulations
-        :return: (jax.Array): Array containing the sample paths
+        Args:
+            maturity (float): Time in years.
+            n (int): Number of steps.
+            n_sim (int): Number of simulations.
+
+        Returns:
+            jax.Array: Array containing the sample paths.
         """
         key = random.PRNGKey(seed)
 
@@ -193,15 +205,17 @@ class MultiGeometricBrownianMotion:
         """
         return self._dim
 
-    def simulate_paths(
-        self, seed: int, maturity: float, n: int, n_sim: int
-    ) -> jax.Array:
+    def sample_paths(self, seed: int, maturity: float, n: int, n_sim: int) -> jax.Array:
         """
-        Simulate a sample of paths from the GBM
+        Simulate a sample of paths from the Multivariate Geometric Brownian Motion (GBM).
 
-        :param maturity: time in years
-        :param n: (int): number of steps
-        :return: (jax.Array): Array containing the sample paths
+        Args:
+            maturity (float): Time in years.
+            n (int): Number of steps.
+            n_sim (int): Number of simulations.
+        
+        Returns:
+            jax.Array: Array containing the sample paths.
         """
         key = random.PRNGKey(seed)
 

--- a/jaxfin/models/heston/__init__.py
+++ b/jaxfin/models/heston/__init__.py
@@ -1,0 +1,6 @@
+"""
+Heston model module
+"""
+from jaxfin.models.heston.heston import MultiHestonModel, UnivHestonModel
+
+__all__ = ["UnivHestonModel", "MultiHestonModel"]

--- a/jaxfin/models/heston/heston.py
+++ b/jaxfin/models/heston/heston.py
@@ -7,6 +7,8 @@ import jax
 import jax.numpy as jnp
 from jax import jit, random
 
+from ..utils import check_symmetric
+
 
 class UnivHestonModel:
     """
@@ -135,7 +137,7 @@ class UnivHestonModel:
 
     def sample_paths(self, seed: int, maturity: float, n: int, n_sim: int):
         """
-        Simulate a sample of paths from the Heston model
+        Sample of paths from the Univariate Heston model
 
         Args:
             seed (int): the seed for the random number generator
@@ -158,6 +160,175 @@ class UnivHestonModel:
         return _sample_paths(
             self.s0, self.v0, self.mean, self.kappa, self.theta, self.sigma, dt, W, Z, n
         )
+
+
+class MultiVariateHestonModel:
+    """Multivariate Heston Model
+
+    Represent a multi-dimensional Heston model
+
+    # Example usage:
+    s0 = jnp.array([100, 100], dtype=jnp.float32)
+    v0 = jnp.array([0.04, 0.04], dtype=jnp.float32)
+    mean = jnp.array([0.05, 0.05], dtype=jnp.float32)
+    kappa = jnp.array([2.0, 2.0], dtype=jnp.float32)
+    theta = jnp.array([0.04, 0.04], dtype=jnp.float32)
+    sigma = jnp.array([0.3, 0.3], dtype=jnp.float32)
+    corr = jnp.array([[1.0, -0.7], [-0.7, 1.0]], dtype=jnp.float32)
+
+    heston_model = MultiVariateHestonModel(s0, v0, mean, kappa, theta, sigma, corr, dtype=jnp.float32)
+    paths = heston_model.sample_paths(seed=42, maturity=1.0, n=100, n_sim=100)
+    """
+
+    def __init__(
+        self,
+        s0: jax.Array,
+        v0: jax.Array,
+        mean: jax.Array,
+        kappa: jax.Array,
+        theta: jax.Array,
+        sigma: jax.Array,
+        corr: jax.Array,
+        dtype: jnp.dtype = jnp.float32,
+    ):
+        """Multivariate Hestion model constructor
+
+        Args:
+            s0 (jax.Array): The initial values of the assets
+            v0 (jax.Array): The initial values of the variance of the assets
+            mean (jax.Array): The mean(drift term) of the assets
+            kappa (jax.Array): The speed of the mean-reversion of the variance
+            theta (jax.Array): The long-term mean of the variance
+            sigma (jax.Array): The volatility of the variance of the assets
+            corr (jax.Array): The correlation matrix of the Heston model
+            dtype (Optional[jnp.dtype], optional): The dtype to use. Defaults to jnp.float32.
+        """
+        if not check_symmetric(corr, 1e-8):
+            raise ValueError("The correlation matrix must be symmetric")
+
+        self._dtype = dtype
+        self._s0 = jnp.asarray(s0, dtype=dtype)
+        self._v0 = jnp.asarray(v0, dtype=dtype)
+        self._mean = jnp.asarray(mean, dtype=dtype)
+        self._kappa = jnp.asarray(kappa, dtype=dtype)
+        self._theta = jnp.asarray(theta, dtype=dtype)
+        self._sigma = jnp.asarray(sigma, dtype=dtype)
+        self._corr = jnp.asarray(corr, dtype=dtype)
+        self._dim = self._s0.shape[0]
+
+    @property
+    def mean(self) -> jax.Array:
+        """Returns the mean of the Heston model
+
+        Returns:
+            jax.Array: The mean of the Heston model
+        """
+        return self._mean
+
+    @property
+    def kappa(self) -> jax.Array:
+        """Returns the speed of the mean-reversion of the variance
+
+        Returns:
+            jax.Array: The speed of the mean-reversion of the variance
+        """
+        return self._kappa
+
+    @property
+    def theta(self) -> jax.Array:
+        """Returns the long-term mean of the variance
+
+        Returns:
+            jax.Array: The long-term mean of the variance
+        """
+        return self._theta
+
+    @property
+    def sigma(self) -> jax.Array:
+        """Returns the volatility of the variance
+
+        Returns:
+            jax.Array: The volatility of the variance
+        """
+        return self._sigma
+
+    @property
+    def s0(self) -> jax.Array:
+        """Returns the initial value of the asset
+
+        Returns:
+            jax.Array: The initial value of the asset
+        """
+        return self._s0
+
+    @property
+    def v0(self) -> jax.Array:
+        """Returns the initial value of the variance of the asset
+
+        Returns:
+            jax.Array: The initial value of the variance of the asset
+        """
+        return self._v0
+
+    @property
+    def corr(self) -> jax.Array:
+        """Returns the correlation matrix of the Heston model
+
+        Returns:
+            jax.Array: The correlation matrix of the Heston model
+        """
+        return self._corr
+
+    @property
+    def dtype(self) -> jax.numpy.dtype:
+        """Returns the underlying dtype of the Heston model
+
+        Returns:
+            jax.numpy.dtype: The underlying dtype of the Heston model
+        """
+        return self._dtype
+
+    def sample_paths(self, seed: int, maturity: float, n: int, n_sim: int) -> jax.Array:
+        """Sample paths from the Multivariate Heston model
+
+        Args:
+            seed (int): The seed for the random number generator
+            maturity (float): The time in years
+            n (int): The number of steps
+            n_sim (int): The number of simulations
+
+        Returns:
+            jax.Array: The simulated paths
+        """
+        key = random.PRNGKey(seed)
+
+        dt = maturity / n
+
+        W = random.normal(key, shape=(n_sim, n * self._dim))
+        Z = random.normal(key, shape=(n_sim, n * self._dim))
+        W = jnp.reshape(W, (n_sim, n, self._dim)).transpose((1, 0, 2))
+        Z = jnp.reshape(Z, (n_sim, n, self._dim)).transpose((1, 0, 2))
+
+        L = jnp.linalg.cholesky(self._corr)
+
+        epsilon_S = W @ L
+        epsilon_v = epsilon_S @ self._corr + Z @ jnp.sqrt(1 - self._corr**2)
+
+        return _sample_paths(
+            self.s0,
+            self.v0,
+            self.mean,
+            self.kappa,
+            self.theta,
+            self.sigma,
+            dt,
+            epsilon_S,
+            epsilon_v,
+            n,
+        )
+
+
+# Helpers
 
 
 def _variance_process_step(
@@ -188,6 +359,28 @@ def _sample_paths(
     Z: jax.Array,
     N: int,
 ) -> jax.Array:
+    """Main function that simulate the path of the Heston model leveragin the
+       jax.lax.while_loop function that allows to perform a loop in a jax makes
+       it useful for reducing compilation times for jit-compiled functions,
+       since native Python loop constructs in an @jit function are unrolled,
+       leading to large XLA computations.
+
+    Args:
+        s0 (jax.Array): The initial price of the stock(s)
+        v0 (jax.Array): The initial variance of the stock(s)
+        mean (jax.Array): The mean of the stock(s)
+        kappa (jax.Array): The speed of the mean-reversion of the variance
+        theta (jax.Array): The long-term mean of the variance
+        sigma (jax.Array): The volatility of the variance of the stock(s)
+        dt (jax.Array): The time step
+        W (jax.Array): The Weiner process of the stock(s)
+        Z (jax.Array): The (correlated) Weiner process of the variance of the stock(s)
+        N (int): The number of steps
+
+    Returns:
+        jax.Array: The simulated paths of the stock(s)
+    """
+
     def init_fn(W, Z):
         W_ = W
         Z_ = Z

--- a/jaxfin/models/heston/heston.py
+++ b/jaxfin/models/heston/heston.py
@@ -162,7 +162,7 @@ class UnivHestonModel:
         )
 
 
-class MultiVariateHestonModel:
+class MultiHestonModel:
     """Multivariate Heston Model
 
     Represent a multi-dimensional Heston model

--- a/jaxfin/models/heston/heston.py
+++ b/jaxfin/models/heston/heston.py
@@ -10,7 +10,7 @@ from jax import jit, random
 
 class UnivHestonModel:
     """
-    Heston Model
+    Univariate Heston Model
 
     Represent a 1-dimensional Heston model
 

--- a/jaxfin/models/heston/heston.py
+++ b/jaxfin/models/heston/heston.py
@@ -1,0 +1,204 @@
+"""
+Heston model class implementation
+"""
+from typing import Optional, Union
+
+import jax
+import jax.numpy as jnp
+from jax import jit, random
+
+
+class UnivHestonModel:
+    """
+    Heston Model
+
+    Represent a 1-dimensional Heston model
+
+    # Example usage:
+    s0 = jnp.array([100], dtype=jnp.float32)
+    v0 = jnp.array([0.04], dtype=jnp.float32)
+    kappa = jnp.array([2.0], dtype=jnp.float32)
+    theta = jnp.array([0.04], dtype=jnp.float32)
+    sigma = jnp.array([0.3], dtype=jnp.float32)
+    rho = jnp.array([-0.7], dtype=jnp.float32)
+
+    heston_model = UnivHestonModel(s0, v0, kappa, theta, sigma, rho, dtype=jnp.float32)
+    paths = heston_model.simulate_paths(maturity=1.0, n=100, n_sim=100)
+    """
+
+    def __init__(
+        self,
+        s0: Union[jax.Array, float],
+        v0: Union[jax.Array, float],
+        mean: Union[jax.Array, float],
+        kappa: Union[jax.Array, float],
+        theta: Union[jax.Array, float],
+        sigma: Union[jax.Array, float],
+        rho: Union[jax.Array, float],
+        dtype: Optional[jax.numpy.dtype] = jnp.float32,
+    ):
+        """Univariate Heston model constructor
+
+        Args:
+            s0 (Union[jax.Array, float]): The initial value of the asset
+            v0 (Union[jax.Array, float]): The initial of the variance of the asset
+            mean (Union[jax.Array, float]): The mean of the asset
+            kappa (Union[jax.Array, float]): The speed of the mean-reversion of the variance
+            theta (Union[jax.Array, float]): The long-term mean of the variance
+            sigma (Union[jax.Array, float]): The volatility of the variance
+            rho (Union[jax.Array, float]): The correlation between the asset and the variance
+            dtype (Optional[jax.numpy.dtype], optional): The type(jnp.float32, ...). Defaults to jnp.float32.
+        """
+        if dtype is None:
+            raise ValueError("dtype must not be None")
+
+        self._dtype = dtype
+        self._s0 = jnp.asarray(s0, dtype=dtype)
+        self._v0 = jnp.asarray(v0, dtype=dtype)
+        self._mean = jnp.asarray(mean, dtype=dtype)
+        self._kappa = jnp.asarray(kappa, dtype=dtype)
+        self._theta = jnp.asarray(theta, dtype=dtype)
+        self._sigma = jnp.asarray(sigma, dtype=dtype)
+        self._rho = jnp.asarray(rho, dtype=dtype)
+
+    @property
+    def mean(self) -> jax.Array:
+        """
+        :return: Returns the mean of the Heston model
+        """
+        return self._mean
+
+    @property
+    def kappa(self) -> jax.Array:
+        """
+        :return: Returns the speed of the mean-reversion of the variance
+        """
+        return self._kappa
+
+    @property
+    def theta(self) -> jax.Array:
+        """
+        :return: Returns the long-term mean of the variance
+        """
+        return self._theta
+
+    @property
+    def sigma(self) -> jax.Array:
+        """
+        :return: Returns the volatility of the variance
+        """
+        return self._sigma
+
+    @property
+    def rho(self) -> jax.Array:
+        """
+        :return: Returns the correlation between the asset and the variance
+        """
+        return self._rho
+
+    @property
+    def s0(self) -> jax.Array:
+        """
+        :return: Returns the initial value of the asset
+        """
+        return self._s0
+
+    @property
+    def v0(self) -> jax.Array:
+        """
+        :return: Returns the initial value of the variance of the asset
+        """
+        return self._v0
+
+    @property
+    def dtype(self) -> jax.numpy.dtype:
+        """
+        :return: Returns the underlying dtype of the Heston model
+        """
+        return self._dtype
+
+    def sample_paths(self, seed: int, maturity: float, n: int, n_sim: int):
+        """
+        Simulate a sample of paths from the Heston model
+
+        Args:
+            seed (int): the seed for the random number generator
+            maturity (float): The time in years
+            n (int): Number of steps (discretization points)
+            n_sim (int): The number of simulations
+        """
+        key = random.PRNGKey(seed)
+
+        dt = maturity / n
+
+        W = random.normal(key, shape=(n_sim, n)).T
+        Z = (
+            self._rho
+            * W
+            * jnp.sqrt(1 - self._rho**2)
+            * random.normal(key, shape=(n_sim, n)).T
+        )
+
+        return _sample_paths(
+            self.s0, self.v0, self.mean, self.kappa, self.theta, self.sigma, dt, W, Z, n
+        )
+
+
+def _variance_process_step(
+    v: jax.Array,
+    kappa: jax.Array,
+    theta: jax.Array,
+    sigma: jax.Array,
+    dt: jax.Array,
+    dZ: jax.Array,
+) -> jax.Array:
+    return (
+        v
+        + kappa * (theta - jnp.maximum(v, 0.0)) * dt
+        + sigma * jnp.sqrt(jnp.maximum(v, 0.0)) * jnp.sqrt(dt) * dZ
+    )
+
+
+@jit
+def _sample_paths(
+    s0: jax.Array,
+    v0: jax.Array,
+    mean: jax.Array,
+    kappa: jax.Array,
+    theta: jax.Array,
+    sigma: jax.Array,
+    dt: jax.Array,
+    W: jax.Array,
+    Z: jax.Array,
+    N: int,
+) -> jax.Array:
+    def init_fn(W, Z):
+        W_ = W
+        Z_ = Z
+
+        S = jnp.full_like(W_, s0)
+        v = jnp.full_like(W_, v0)
+
+        return 0, S, v, W_, Z_
+
+    def cond_fn(val):
+        i, *_ = val
+        return i < N
+
+    def body_val(val):
+        i, S, v, W, Z = val
+        dW = W[i]
+        dZ = Z[i]
+
+        S = S.at[i + 1].set(
+            S[i]
+            * jnp.exp((mean - 0.5 * v[i]) * dt + jnp.sqrt(v[i]) * jnp.sqrt(dt) * dW)
+        )
+
+        v = v.at[i + 1].set(_variance_process_step(v[i], kappa, theta, sigma, dt, dZ))
+
+        return i + 1, S, v, W, Z
+
+    _, S, _, _, _ = jax.lax.while_loop(cond_fn, body_val, init_fn(W, Z))
+
+    return S

--- a/jaxfin/models/heston/heston.py
+++ b/jaxfin/models/heston/heston.py
@@ -63,57 +63,73 @@ class UnivHestonModel:
 
     @property
     def mean(self) -> jax.Array:
-        """
-        :return: Returns the mean of the Heston model
+        """Returns the mean of the Heston model
+
+        Returns:
+            jax.Array: The mean of the Heston model
         """
         return self._mean
 
     @property
     def kappa(self) -> jax.Array:
-        """
-        :return: Returns the speed of the mean-reversion of the variance
+        """Returns the speed of the mean-reversion of the variance
+
+        Returns:
+            jax.Array: The speed of the mean-reversion of the variance
         """
         return self._kappa
 
     @property
     def theta(self) -> jax.Array:
-        """
-        :return: Returns the long-term mean of the variance
+        """Returns the long-term mean of the variance
+
+        Returns:
+            jax.Array: The long-term mean of the variance
         """
         return self._theta
 
     @property
     def sigma(self) -> jax.Array:
-        """
-        :return: Returns the volatility of the variance
+        """Returns the volatility of the variance
+
+        Returns:
+            jax.Array: The volatility of the variance
         """
         return self._sigma
 
     @property
     def rho(self) -> jax.Array:
-        """
-        :return: Returns the correlation between the asset and the variance
+        """Returns the correlation between the asset and the variance
+
+        Returns:
+            jax.Array: The correlation between the asset and the variance
         """
         return self._rho
 
     @property
     def s0(self) -> jax.Array:
-        """
-        :return: Returns the initial value of the asset
+        """Returns the initial value of the asset
+
+        Returns:
+            jax.Array: The initial value of the asset
         """
         return self._s0
 
     @property
     def v0(self) -> jax.Array:
-        """
-        :return: Returns the initial value of the variance of the asset
+        """Returns the initial value of the variance of the asset
+
+        Returns:
+            jax.Array: The initial value of the variance of the asset
         """
         return self._v0
 
     @property
     def dtype(self) -> jax.numpy.dtype:
-        """
-        :return: Returns the underlying dtype of the Heston model
+        """Returns the underlying dtype of the Heston model
+
+        Returns:
+            jax.numpy.dtype: The underlying dtype of the Heston model
         """
         return self._dtype
 

--- a/jaxfin/models/utils.py
+++ b/jaxfin/models/utils.py
@@ -1,0 +1,16 @@
+"""
+Utils funciton of the model module
+"""
+import jax
+import jax.numpy as jnp
+
+
+def check_symmetric(a: jax.Array, tol=1e-8):
+    """
+    Check if a matrix is symmetric
+
+    :param a: (jax.Array): Matrix to check
+    :param tol: (float): Tolerance for the check
+    :return: (bool): True if the matrix is symmetric
+    """
+    return jnp.all(jnp.abs(a - a.T) < tol)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,7 +296,7 @@ valid-metaclass-classmethod-first-arg = ["mcs"]
 max-args = 10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes = 7
+max-attributes = 10
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr = 5

--- a/tests/models/test_gbm.py
+++ b/tests/models/test_gbm.py
@@ -25,7 +25,7 @@ class TestUnivGBM:
         dtype = jnp.float32
         gbm = UnivGeometricBrownianMotion(s0, mean, sigma, dtype)
 
-        stock_paths = gbm.simulate_paths(SEED, 1.0, 52, 100)
+        stock_paths = gbm.sample_paths(SEED, 1.0, 52, 100)
 
         assert stock_paths.shape == (52, 100)
 
@@ -55,6 +55,6 @@ class TestMultiGBM:
         corr = jnp.array([[1, 0.1], [0.1, 1]])
         dtype = jnp.float32
         gbm = MultiGeometricBrownianMotion(s0, mean, sigma, corr, dtype)
-        sample_path = gbm.simulate_paths(SEED, 1.0, 52, 100)
+        sample_path = gbm.sample_paths(SEED, 1.0, 52, 100)
 
         assert sample_path.shape == (52, 100, 2)

--- a/tests/models/test_heston.py
+++ b/tests/models/test_heston.py
@@ -1,5 +1,5 @@
 import jax.numpy as jnp
-from jaxfin.models.heston.heston import UnivHestonModel, MultiVariateHestonModel
+from jaxfin.models.heston.heston import UnivHestonModel, MultiHestonModel
 
 SEED: int = 42
 
@@ -53,7 +53,7 @@ class TestMultiHestonModel():
         corr = jnp.array([[1.0, 0.5], [0.5, 1.0]], dtype=jnp.float32)
         dtype = jnp.float32
 
-        heston_model = MultiVariateHestonModel(s0, v0, mean, kappa, theta, sigma, corr, dtype=dtype)
+        heston_model = MultiHestonModel(s0, v0, mean, kappa, theta, sigma, corr, dtype=dtype)
 
         assert jnp.all(heston_model.mean == mean)
         assert jnp.all(heston_model.kappa == kappa)
@@ -73,7 +73,7 @@ class TestMultiHestonModel():
         sigma = jnp.array([0.3, 0.3], dtype=jnp.float32)
         corr = jnp.array([[1.0, 0.5], [0.5, 1.0]], dtype=jnp.float32)
 
-        heston_model = MultiVariateHestonModel(s0, v0, mean, kappa, theta, sigma, corr, dtype=jnp.float32)
+        heston_model = MultiHestonModel(s0, v0, mean, kappa, theta, sigma, corr, dtype=jnp.float32)
         paths = heston_model.sample_paths(seed=SEED, maturity=1.0, n=100, n_sim=100)
 
         assert paths.shape == (100, 100, 2)

--- a/tests/models/test_heston.py
+++ b/tests/models/test_heston.py
@@ -1,5 +1,5 @@
 import jax.numpy as jnp
-from jaxfin.models.heston.heston import UnivHestonModel
+from jaxfin.models.heston.heston import UnivHestonModel, MultiVariateHestonModel
 
 SEED: int = 42
 
@@ -39,3 +39,41 @@ class TestUnivHestonModel():
         paths = heston_model.sample_paths(seed=SEED, maturity=1.0, n=100, n_sim=100)
 
         assert paths.shape == (100, 100)
+
+
+class TestMultiHestonModel():
+
+    def test_init(self):
+        s0 = jnp.array([100, 100], dtype=jnp.float32)
+        v0 = jnp.array([0.2, 0.2], dtype=jnp.float32)
+        mean = jnp.array([0.2, 0.2], dtype=jnp.float32)
+        kappa = jnp.array([2.0, 2.0], dtype=jnp.float32)
+        theta = jnp.array([0.25, 0.25], dtype=jnp.float32)
+        sigma = jnp.array([0.3, 0.3], dtype=jnp.float32)
+        corr = jnp.array([[1.0, 0.5], [0.5, 1.0]], dtype=jnp.float32)
+        dtype = jnp.float32
+
+        heston_model = MultiVariateHestonModel(s0, v0, mean, kappa, theta, sigma, corr, dtype=dtype)
+
+        assert jnp.all(heston_model.mean == mean)
+        assert jnp.all(heston_model.kappa == kappa)
+        assert jnp.all(heston_model.theta == theta)
+        assert jnp.all(heston_model.sigma == sigma)
+        assert jnp.all(heston_model.corr == corr)
+        assert heston_model.dtype == dtype
+        assert jnp.all(heston_model.s0 == s0)
+        assert jnp.all(heston_model.v0 == v0)
+
+    def test_sample_paths(self):
+        s0 = jnp.array([100, 100], dtype=jnp.float32)
+        v0 = jnp.array([0.2, 0.2], dtype=jnp.float32)
+        mean = jnp.array([0.2, 0.2], dtype=jnp.float32)
+        kappa = jnp.array([2.0, 2.0], dtype=jnp.float32)
+        theta = jnp.array([0.25, 0.25], dtype=jnp.float32)
+        sigma = jnp.array([0.3, 0.3], dtype=jnp.float32)
+        corr = jnp.array([[1.0, 0.5], [0.5, 1.0]], dtype=jnp.float32)
+
+        heston_model = MultiVariateHestonModel(s0, v0, mean, kappa, theta, sigma, corr, dtype=jnp.float32)
+        paths = heston_model.sample_paths(seed=SEED, maturity=1.0, n=100, n_sim=100)
+
+        assert paths.shape == (100, 100, 2)

--- a/tests/models/test_heston.py
+++ b/tests/models/test_heston.py
@@ -1,0 +1,41 @@
+import jax.numpy as jnp
+from jaxfin.models.heston.heston import UnivHestonModel
+
+SEED: int = 42
+
+class TestUnivHestonModel():
+
+    def test_init(self):
+        s0 = 100
+        v0 = 0.2
+        mean = 0.2
+        kappa = 2.0
+        theta = 0.25
+        sigma = 0.3
+        rho = -0.7
+        dtype = jnp.float32
+
+        heston_model = UnivHestonModel(s0, v0, mean, kappa, theta, sigma, rho, dtype=dtype)
+
+        assert heston_model.mean == mean
+        assert heston_model.kappa == kappa
+        assert heston_model.theta == theta
+        assert heston_model.sigma == sigma
+        assert heston_model.rho == rho
+        assert heston_model.dtype == dtype
+        assert heston_model.s0 == s0
+        assert heston_model.v0 == v0
+
+    def test_sample_paths(self):
+        s0 = jnp.array(100, dtype=jnp.float32)
+        v0 = jnp.array(0.2, dtype=jnp.float32)
+        mean = jnp.array(0.2, dtype=jnp.float32)
+        kappa = jnp.array(2.0, dtype=jnp.float32)
+        theta = jnp.array(0.25, dtype=jnp.float32)
+        sigma = jnp.array(0.3, dtype=jnp.float32)
+        rho = jnp.array(-0.7, dtype=jnp.float32)
+
+        heston_model = UnivHestonModel(s0, v0, mean, kappa, theta, sigma, rho, dtype=jnp.float32)
+        paths = heston_model.sample_paths(seed=SEED, maturity=1.0, n=100, n_sim=100)
+
+        assert paths.shape == (100, 100)


### PR DESCRIPTION
Heston model implementation.
Implemented both the univariate version (`UnivHestonModel` under `jaxfin.models.heston`) and the multivariate model (`MultiHestonModel` still under under `jaxfin.models.heston`). To implement the multivariate one I based myself on [A parsimonious multi-asset Heston model: calibration and derivative pricing](https://d-nb.info/1027389406/34), and I've used [`jax.lax.while_loop`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.while_loop.html) to speed up the simulation of the paths since there is no simple way to make as vectorized calculation, and I wanted to keep the code simple for the simulations.