### PR TITLE
Implemented Inverse fourier method for European option pricing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ type:
 lint:
 	ruff check jaxfin --output-format=full
 
+complete-lint:
+	lint
+	pylint jaxfin --output-format=text:pylint_res.txt,colorized
+
 format:
 	# Sort imports
 	isort ${LINT_PATHS}

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,7 @@ complete-lint:
 	pylint jaxfin --output-format=text:pylint_res.txt,colorized
 
 format:
-	# Sort imports
 	isort ${LINT_PATHS}
-	# Reformat using black
 	black ${LINT_PATHS}
 
 check-codestyle:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+SHELL=/bin/bash
+LINT_PATHS=jaxfin/ tests/
+
+pytest:
+	python -m pytest --no-header -vv --html=test_report.html --self-contained-html
+
+type: 
+	mypy ${LINT_PATHS}
+
+lint:
+	ruff check jaxfin --output-format=full
+
+format:
+	# Sort imports
+	isort ${LINT_PATHS}
+	# Reformat using black
+	black ${LINT_PATHS}
+
+check-codestyle:
+	black ${LINT_PATHS} --check
+
+commit-checks: format type lint
+
+release: 
+	python -m build
+	twine upload dist/*
+
+test-release: 
+	python -m build
+	twine upload dist/* -r testpypi
+
+.PHONY: clean spelling doc lint format check-codestyle commit-checks

--- a/README.md
+++ b/README.md
@@ -44,20 +44,24 @@ discount_rates = jnp.asarray([0.0])
 european_price(spots, strikes, expires, vols, discount_rates, dtype=jnp.float32)
 ```
 
-Computing the price price of a single option, nahh that's boring! what we can do with jaxfin is to compute the price of a basket of options leveraging the vectorization capabilities of `jax`:
+Computing the price price of a single option, nahh that's boring! what we can do with jaxfin is to compute the price of a basket of options leveraging the vectorization capabilities of `jax` using `jax.vmap`:
 
 ```python
+from jax import vmap
 import jax.numpy as jnp
 from jaxfin.price_engine.black_scholes import european_price
 
+v_european_price = vmap(european_price, in_axes=(0, None, None, None, None))
+
 # Black-Scholes price of an european option
-spots = jnp.asarray([100, 110, 120])
-strikes = jnp.asarray([110, 120, 130])
-expires = jnp.asarray([1.0, 1.0, 1.0])
-vols = jnp.asarray([0.2, 0.2, 0.2])
-discount_rates = jnp.asarray([0.0, 0.0, 0.0])
-are_calls = jnp.array([True, False, False, True, True], dtype=jnp.bool_)
-european_price(spots, strikes, expires, vols, discount_rates, are_calls, dtype=jnp.float32)
+spots = jnp.asarray([80, 90, 100, 110, 120])
+strikes = jnp.asarray(110)
+expires = jnp.asarray(1.0)
+vols = jnp.asarray(0.2)
+discount_rates = jnp.asarray(0.0)
+v_european_price(spots, strikes, expires, vols, discount_rates)
+
+>> Array([0.4424405, 1.6421748, 4.292015, 8.762122, 15.010387], dtype=float32)
 ```
 
 In addition to that the calculation of the greeks, is done not throught the closed form formulas but through the automatic differentiation capabilities of `jax`. For example the function that calculates the delta of the european option under the Black Scholes model can be simply obtained as follows:
@@ -83,6 +87,9 @@ delta_european(spots, strikes, expires, vols, discount_rates, dtype=jnp.float32)
     - Black model
         - Pricing european options
         - Greeks of european options (just delta and gamma)
+    - Fourier methods
+        - Pricing european options using inverse fourier transform
+        - Greeks of european options (just delta)
 - Models
     - Geometric brownian motion
       - Univariate 
@@ -128,6 +135,18 @@ To achieve that the following scripts have been provided
 - `scripts\run-tests.bat`: This script runs the unit tests for the project.
 - `scripts\run-mypy.bat`: This script runs Mypy, a static type checker for Python. Mypy can catch certain types of errors at compile time that would otherwise only be caught at runtime in standard Python. It's a way to get some of the benefits of static typing in a dynamically typed language.
 - `scripts\check-black.bat`: This script runs Black, the "uncompromising" Python code formatter. By using it, you ensure that your codebase has a consistent style, which can make it easier to read and maintain.
+
+Otherwise a `Makefile` have been provided to run all the pre-commit checks at once:
+
+```bash
+make commit-checks
+```
+
+To run the tests you can use the following command:
+
+```bash
+make pytest
+```
 
 ## Contributing
 

--- a/jaxfin/price_engine/fft/__init__.py
+++ b/jaxfin/price_engine/fft/__init__.py
@@ -1,0 +1,8 @@
+"""
+Fast Fourier Transform (FFT) submodule for price engine.
+"""
+from jaxfin.price_engine.fft.vanilla_options import (
+    fourier_inv_call,
+    fourier_inv_put,
+    delta_call_fourier
+)

--- a/jaxfin/price_engine/fft/__init__.py
+++ b/jaxfin/price_engine/fft/__init__.py
@@ -2,7 +2,13 @@
 Fast Fourier Transform (FFT) submodule for price engine.
 """
 from jaxfin.price_engine.fft.vanilla_options import (
+    delta_call_fourier,
     fourier_inv_call,
     fourier_inv_put,
-    delta_call_fourier
 )
+
+__all__ = [
+    "fourier_inv_call",
+    "fourier_inv_put",
+    "delta_call_fourier",
+]

--- a/jaxfin/price_engine/fft/vanilla_options.py
+++ b/jaxfin/price_engine/fft/vanilla_options.py
@@ -1,14 +1,16 @@
-from jax import jit
+"""
+This module contains functions to price vanilla options using the Fourier inversion method.
+"""
+from functools import partial
+from typing import Callable
+
 import jax.numpy as jnp
+from jax import Array, jit
 from jax.scipy.integrate import trapezoid
 from jax.typing import ArrayLike
 
-from functools import partial
 
-from typing import Callable
-
-
-def _compute_probabilities(right_lim: ArrayLike, integrand_fn: Callable) -> float:
+def _compute_probabilities(right_lim: ArrayLike, integrand_fn: Callable) -> Array:
     """
     Compute the probabilities q1 and q2 for the Fourier inversion method
 
@@ -89,7 +91,7 @@ def fourier_inv_call(
     sigma: float,
     kappa: float,
     rho: float,
-):
+) -> Array:
     """
     Price of a call option using the Fourier inversion method
 
@@ -132,7 +134,7 @@ def fourier_inv_put(
     sigma: float,
     kappa: float,
     rho: float,
-):
+) -> Array:
     """
     Price of a put option using the Fourier inversion method
 
@@ -175,7 +177,7 @@ def delta_call_fourier(
     sigma: float,
     kappa: float,
     rho: float,
-):
+) -> Array:
     """
     Computes the delta of a call option using the Heston model.
 

--- a/jaxfin/price_engine/fft/vanilla_options.py
+++ b/jaxfin/price_engine/fft/vanilla_options.py
@@ -1,0 +1,204 @@
+from jax import jit
+import jax.numpy as jnp
+from jax.scipy.integrate import trapezoid
+from jax.typing import ArrayLike
+
+from functools import partial
+
+from typing import Callable
+
+
+def _compute_probabilities(right_lim: ArrayLike, integrand_fn: Callable) -> float:
+    """
+    Compute the probabilities q1 and q2 for the Fourier inversion method
+
+    Args:
+        right_lim (int): The right limit of the integral
+        integrand_fn (Callable): The integrand function
+
+    Returns:
+        float: The value of the probabilities q1 and q2
+    """
+    u_values = jnp.linspace(1e-15, right_lim, num=1000)
+    integral = trapezoid(integrand_fn(u_values), u_values)
+
+    return 1 / 2 + 1 / jnp.pi * integral
+
+
+def cf_heston(
+    u: float,
+    t: float,
+    v0: float,
+    mu: float,
+    kappa: float,
+    theta: float,
+    sigma: float,
+    rho: float,
+):
+    """
+    Heston characteristic function
+
+    Args:
+        u (float): The argument of the characteristic function
+        t (float): The time to maturity
+        v0 (float): The initial variance
+        mu (float): The risk-neutral drift
+        theta (float): The long-term variance
+        sigma (float): The volatility of the variance
+        kappa (float): The rate at which the variance reverts to theta
+        rho (float): The correlation between the asset and the variance
+
+    Returns:
+        float: The value of the characteristic function at u
+    """
+    xi = kappa - sigma * rho * u * 1j
+    d = jnp.sqrt(xi**2 + sigma**2 * (u**2 + 1j * u))
+    g1 = (xi + d) / (xi - d)
+    g2 = 1 / g1
+    cf = jnp.exp(
+        1j * u * mu * t
+        + (kappa * theta)
+        / (sigma**2)
+        * ((xi - d) * t - 2 * jnp.log((1 - g2 * jnp.exp(-d * t)) / (1 - g2)))
+        + (v0 / sigma**2)
+        * (xi - d)
+        * (1 - jnp.exp(-d * t))
+        / (1 - g2 * jnp.exp(-d * t))
+    )
+    return cf
+
+
+def _integrand_q1(u, k, cf):
+    return jnp.real(
+        (jnp.exp(-u * k * 1j) / (u * 1j)) * cf(u - 1j) / cf(-1.0000000000001j)
+    )
+
+
+def _integrand_q2(u, k, cf):
+    return jnp.real(jnp.exp(-u * k * 1j) / (u * 1j) * cf(u))
+
+
+@jit
+def fourier_inv_call(
+    s0: float,
+    K: float,
+    T: float,
+    v0: float,
+    mu: float,
+    theta: float,
+    sigma: float,
+    kappa: float,
+    rho: float,
+):
+    """
+    Price of a call option using the Fourier inversion method
+
+    Args:
+        s0 (float): The initial value of the underlying asset
+        K (float): The strike price
+        T (float): The time to maturity
+        v0 (float): The initial variance
+        mu (float): The risk-neutral drift
+        theta (float): The long-term variance
+        sigma (float): The volatility of the variance
+        kappa (float): The rate at which the variance reverts to theta
+        rho (float): The correlation between the asset and the variance
+
+    Returns:
+        float: The price of the call option
+    """
+    cf = partial(
+        cf_heston, t=T, v0=v0, mu=mu, kappa=kappa, theta=theta, sigma=sigma, rho=rho
+    )
+    right_lim = 1000
+    k = jnp.log(K / s0)
+
+    integrand_q1 = partial(_integrand_q1, k=k, cf=cf)
+    integrand_q2 = partial(_integrand_q2, k=k, cf=cf)
+
+    q1 = _compute_probabilities(right_lim, integrand_q1)
+    q2 = _compute_probabilities(right_lim, integrand_q2)
+    return s0 * q1 - K * jnp.exp(-mu * T) * q2
+
+
+@jit
+def fourier_inv_put(
+    s0: float,
+    K: float,
+    T: float,
+    v0: float,
+    mu: float,
+    theta: float,
+    sigma: float,
+    kappa: float,
+    rho: float,
+):
+    """
+    Price of a put option using the Fourier inversion method
+
+    Args:
+        s0 (float): The initial value of the underlying asset
+        K (float): The strike price
+        T (float): The time to maturity
+        v0 (float): The initial variance
+        mu (float): The risk-neutral drift
+        theta (float): The long-term variance
+        sigma (float): The volatility of the variance
+        kappa (float): The rate at which the variance reverts to theta
+        rho (float): The correlation between the asset and the variance
+
+    Returns:
+        float: The price of the put option
+    """
+    cf = partial(
+        cf_heston, t=T, v0=v0, mu=mu, kappa=kappa, theta=theta, sigma=sigma, rho=rho
+    )
+    right_lim = 1000
+    k = jnp.log(K / s0)
+
+    integrand_q1 = partial(_integrand_q1, k=k, cf=cf)
+    integrand_q2 = partial(_integrand_q2, k=k, cf=cf)
+
+    q1 = _compute_probabilities(right_lim, integrand_q1)
+    q2 = _compute_probabilities(right_lim, integrand_q2)
+    return K * jnp.exp(-mu * T) * (1 - q2) - s0 * (1 - q1)
+
+
+@jit
+def delta_call_fourier(
+    s0: float,
+    K: float,
+    T: float,
+    v0: float,
+    mu: float,
+    theta: float,
+    sigma: float,
+    kappa: float,
+    rho: float,
+):
+    """
+    Computes the delta of a call option using the Heston model.
+
+    Parameters:
+    s0 (float): Initial stock price.
+    K (float): Strike price of the option.
+    T (float): Time to maturity of the option.
+    v0 (float): Initial variance.
+    mu (float): Risk-free rate.
+    theta (float): Long-term mean of the variance process.
+    sigma (float): Volatility of the variance process.
+    kappa (float): Rate at which the variance reverts to its long-term mean.
+    rho (float): Correlation between the stock price and variance processes.
+
+    Returns:
+        float: Delta of the call option.
+    """
+    cf = partial(
+        cf_heston, t=T, v0=v0, mu=mu, kappa=kappa, theta=theta, sigma=sigma, rho=rho
+    )
+    right_lim = 1000
+    k = jnp.log(K / s0)
+
+    integrand_q1 = partial(_integrand_q1, k=k, cf=cf)
+
+    return _compute_probabilities(right_lim, integrand_q1)

--- a/tests/models/test_gbm.py
+++ b/tests/models/test_gbm.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
 
-from jaxfin.models.gbm import UnivGeometricBrownianMotion, MultiGeometricBrownianMotion
+from jaxfin.models.gbm import MultiGeometricBrownianMotion, UnivGeometricBrownianMotion
 
 SEED: int = 42
 

--- a/tests/models/test_heston.py
+++ b/tests/models/test_heston.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
-from jaxfin.models.heston.heston import UnivHestonModel, MultiHestonModel
+
+from jaxfin.models.heston.heston import MultiHestonModel, UnivHestonModel
 
 SEED: int = 42
 

--- a/tests/price_engine/test_black.py
+++ b/tests/price_engine/test_black.py
@@ -1,11 +1,10 @@
 import jax.numpy as jnp
-
 import pytest
 
 from jaxfin.price_engine.black import (
-    future_option_price,
     future_option_delta,
     future_option_gamma,
+    future_option_price,
 )
 from jaxfin.price_engine.utils.vect import get_vfunction
 

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -1,18 +1,17 @@
+import logging
+
 import jax.numpy as jnp
+import pytest
 
 from jaxfin.price_engine.black_scholes import (
-    european_price,
     delta_european,
+    european_price,
     gamma_european,
-    theta_european,
     rho_european,
+    theta_european,
     vega_european,
 )
 from jaxfin.price_engine.utils.vect import get_vfunction
-
-import logging
-
-import pytest
 
 TOL = 1e-3
 DTYPE = jnp.float32

--- a/tests/price_engine/test_fft.py
+++ b/tests/price_engine/test_fft.py
@@ -1,13 +1,17 @@
 import jax.numpy as jnp
 from jax import vmap
 
-from jaxfin.price_engine.fft import delta_call_fourier, fourier_inv_call
+from jaxfin.price_engine.fft import (
+    delta_call_fourier,
+    fourier_inv_call,
+    fourier_inv_put,
+)
 
 TOL = 1e-3
 DTYPE = jnp.float32
 
 
-def test_one_vanilla():
+def test_one_vanilla_call():
     spot = 100
     strike = 110
     expire = 1.0
@@ -24,7 +28,24 @@ def test_one_vanilla():
     assert jnp.array_equal(price, expected_price)
 
 
-def test_one_delta_vanilla():
+def test_one_vanilla_put():
+    spot = 100
+    strike = 110
+    expire = 1.0
+    v0 = 0.2
+    theta = 0.3
+    rate = 0.0
+    sigma = 0.3
+    kappa = 2.0
+    rho = -0.6
+
+    price = fourier_inv_put(spot, strike, expire, v0, rate, theta, sigma, kappa, rho)
+    expected_price_put = jnp.asarray(25.846123, dtype=DTYPE)
+
+    assert jnp.array_equal(price, expected_price_put)
+
+
+def test_one_delta_vanilla_call():
     spot = 100
     strike = 110
     expire = 1.0
@@ -41,7 +62,7 @@ def test_one_delta_vanilla():
     assert jnp.array_equal(delta, expected_delta)
 
 
-def test_array_vanilla():
+def test_array_vanilla_call():
     v_fouirer_inv_call = vmap(
         fourier_inv_call, in_axes=(0, None, None, None, None, None, None, None, None)
     )
@@ -63,7 +84,29 @@ def test_array_vanilla():
     assert jnp.allclose(prices, expected, atol=TOL)
 
 
-def test_array_delta_vanilla():
+def test_array_vanilla_put():
+    v_fouirer_inv_put = vmap(
+        fourier_inv_put, in_axes=(0, None, None, None, None, None, None, None, None)
+    )
+    spots = jnp.array([100, 90, 80, 110, 120], dtype=DTYPE)
+    strikes = jnp.array(110, dtype=DTYPE)
+    expires = jnp.array(1.0, dtype=DTYPE)
+    v0 = 0.2
+    theta = 0.3
+    rate = 0.0
+    sigma = 0.3
+    kappa = 2.0
+    rho = -0.6
+
+    prices = v_fouirer_inv_put(
+        spots, strikes, expires, v0, rate, theta, sigma, kappa, rho
+    )
+    expected = jnp.array([25.846123, 30.871, 36.825214, 21.644054, 18.149118])
+
+    assert jnp.allclose(prices, expected, atol=TOL)
+
+
+def test_array_delta_vanilla_call():
     v_delta_call_fourier = vmap(
         delta_call_fourier, in_axes=(0, None, None, None, None, None, None, None, None)
     )

--- a/tests/price_engine/test_fft.py
+++ b/tests/price_engine/test_fft.py
@@ -1,0 +1,85 @@
+import jax.numpy as jnp
+from jax import vmap
+
+from jaxfin.price_engine.fft import delta_call_fourier, fourier_inv_call
+
+TOL = 1e-3
+DTYPE = jnp.float32
+
+
+def test_one_vanilla():
+    spot = 100
+    strike = 110
+    expire = 1.0
+    v0 = 0.2
+    theta = 0.3
+    rate = 0.0
+    sigma = 0.3
+    kappa = 2.0
+    rho = -0.6
+
+    price = fourier_inv_call(spot, strike, expire, v0, rate, theta, sigma, kappa, rho)
+    expected_price = jnp.asarray(15.846119, dtype=DTYPE)
+
+    assert jnp.array_equal(price, expected_price)
+
+
+def test_one_delta_vanilla():
+    spot = 100
+    strike = 110
+    expire = 1.0
+    v0 = 0.2
+    theta = 0.3
+    rate = 0.0
+    sigma = 0.3
+    kappa = 2.0
+    rho = -0.6
+
+    delta = delta_call_fourier(spot, strike, expire, v0, rate, theta, sigma, kappa, rho)
+    expected_delta = jnp.asarray(0.540566, dtype=DTYPE)
+
+    assert jnp.array_equal(delta, expected_delta)
+
+
+def test_array_vanilla():
+    v_fouirer_inv_call = vmap(
+        fourier_inv_call, in_axes=(0, None, None, None, None, None, None, None, None)
+    )
+    spots = jnp.array([100, 90, 80, 110, 120], dtype=DTYPE)
+    strikes = jnp.array(110, dtype=DTYPE)
+    expires = jnp.array(1.0, dtype=DTYPE)
+    v0 = 0.2
+    theta = 0.3
+    rate = 0.0
+    sigma = 0.3
+    kappa = 2.0
+    rho = -0.6
+
+    prices = v_fouirer_inv_call(
+        spots, strikes, expires, v0, rate, theta, sigma, kappa, rho
+    )
+    expected = jnp.array([15.846119, 10.871005, 6.8252187, 21.644053, 28.149117])
+
+    assert jnp.allclose(prices, expected, atol=TOL)
+
+
+def test_array_delta_vanilla():
+    v_delta_call_fourier = vmap(
+        delta_call_fourier, in_axes=(0, None, None, None, None, None, None, None, None)
+    )
+    spots = jnp.array([100, 90, 80, 110, 120], dtype=DTYPE)
+    strikes = jnp.array(110, dtype=DTYPE)
+    expires = jnp.array(1.0, dtype=DTYPE)
+    v0 = 0.2
+    theta = 0.3
+    rate = 0.0
+    sigma = 0.3
+    kappa = 2.0
+    rho = -0.6
+
+    deltas = v_delta_call_fourier(
+        spots, strikes, expires, v0, rate, theta, sigma, kappa, rho
+    )
+    expected = jnp.array([0.540566, 0.45264322, 0.3552375, 0.61707103, 0.6820846])
+
+    assert jnp.allclose(deltas, expected, atol=TOL)


### PR DESCRIPTION
Implemented under the `price_engine\fft` module

- `fourier_inv_call`: Price of a European call option using the Fourier inversion method
- `fourier_inv_put`: Price of a European put option using the Fourier inversion method
- `delta_call_fourier`: Computes the delta of a call option using the Heston model.